### PR TITLE
Fixed New-Push and Remove-Push functions

### DIFF
--- a/PassPushPosh/PassPushPosh.psm1
+++ b/PassPushPosh/PassPushPosh.psm1
@@ -878,7 +878,7 @@ function New-Push {
         Write-Verbose "Sending HTTP request (minus body): $($iwrSplat | Select-Object Method,ContentType,Uri,UserAgent,Headers | Out-String)"
         if ($PSCmdlet.ShouldProcess($shouldString, $iwrSplat.Uri, 'Submit new Push')) {
             try {
-                $response = Invoke-WebRequest -Uri "$Global:PPPBaseUrl/$Language/p.json" -Method Post -ContentType 'application/json' -Body ($body | ConvertTo-Json)
+                $response = Invoke-WebRequest @iwrSplat
                 if ($DebugPreference -eq [System.Management.Automation.ActionPreference]::Continue) {
                     Set-Variable -Scope Global -Name PPPLastCall -Value $response
                     Write-Debug 'Response to Invoke-WebRequest set to PPPLastCall Global variable'
@@ -963,7 +963,7 @@ function Remove-Push {
         try {
             if ($PSCmdlet.ParameterSetName -eq 'Object') {
                 Write-Debug -Message "Remove-Push was passed a PasswordPush object with URLToken: [$($PushObject.URLToken)]"
-                if (-not $PushObject.IsDeletableByViewer -and -not $Global.PPPHeaders) { #Pre-qualify if this will succeed
+                if (-not $PushObject.IsDeletableByViewer -and -not $Global:PPPHeaders) { #Pre-qualify if this will succeed
                     Write-Warning -Message 'Unable to remove Push. Push is not marked as deletable by viewer and you are not authenticated.'
                     return $false
                 }

--- a/PassPushPosh/Public/New-Push.ps1
+++ b/PassPushPosh/Public/New-Push.ps1
@@ -167,7 +167,7 @@ function New-Push {
         Write-Verbose "Sending HTTP request (minus body): $($iwrSplat | Select-Object Method,ContentType,Uri,UserAgent,Headers | Out-String)"
         if ($PSCmdlet.ShouldProcess($shouldString, $iwrSplat.Uri, 'Submit new Push')) {
             try {
-                $response = Invoke-WebRequest -Uri "$Global:PPPBaseUrl/$Language/p.json" -Method Post -ContentType 'application/json' -Body ($body | ConvertTo-Json)
+                $response = Invoke-WebRequest @iwrSplat
                 if ($DebugPreference -eq [System.Management.Automation.ActionPreference]::Continue) {
                     Set-Variable -Scope Global -Name PPPLastCall -Value $response
                     Write-Debug 'Response to Invoke-WebRequest set to PPPLastCall Global variable'

--- a/PassPushPosh/Public/Remove-Push.ps1
+++ b/PassPushPosh/Public/Remove-Push.ps1
@@ -63,7 +63,7 @@
         try {
             if ($PSCmdlet.ParameterSetName -eq 'Object') {
                 Write-Debug -Message "Remove-Push was passed a PasswordPush object with URLToken: [$($PushObject.URLToken)]"
-                if (-not $PushObject.IsDeletableByViewer -and -not $Global.PPPHeaders) { #Pre-qualify if this will succeed
+                if (-not $PushObject.IsDeletableByViewer -and -not $Global:PPPHeaders) { #Pre-qualify if this will succeed
                     Write-Warning -Message 'Unable to remove Push. Push is not marked as deletable by viewer and you are not authenticated.'
                     return $false
                 }


### PR DESCRIPTION
Updated New-Push API request to use authenticated call properly. Updated validation for if PasswordPush object is deletable by viewer and user is authenticated.